### PR TITLE
fix: ignore no-template-curly-in-string eslint

### DIFF
--- a/src/lib/GoCart.js
+++ b/src/lib/GoCart.js
@@ -34,6 +34,7 @@ class GoCart {
             cartMode: 'drawer',
             drawerDirection: 'right',
             displayModal: false,
+            // eslint-disable-next-line no-template-curly-in-string
             moneyFormat: '${{amount}}',
         };
 


### PR DESCRIPTION
ESLint thrown warnings for something that is OK. Warnings would throw errors in CI so it's better to prevent it